### PR TITLE
Remove bot accounts that do not exist anymore

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,6 @@ Diese Accounts werden von anderen Personen betrieben und sind unabhängig entsta
 
 * [@impfstatus](https://twitter.com/impfstatus) 
 * [@ImpfStatusGER](https://twitter.com/ImpfStatusGER) 
-* [@BotImpf](https://twitter.com/BotImpf)
 * [@GermanyProgress](https://twitter.com/GermanyProgress)
 * [@impftracker](https://twitter.com/impftracker)
 * [@CoronaBot_DEU](https://twitter.com/CoronaBot_DEU)


### PR DESCRIPTION
The twitter profile @BotImpf (https://twitter.com/BotImpf) does not seem to exist anymore.