### PR TITLE
Update Venv activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,7 @@ py -3 venv venv
 # Activate venv: Windows
 venv\Scripts\activate.bat 
 
-# Activate venv: Linux
-venv\bin\activate
-
-# Activate venv: MacOS
+# Activate venv: Linux / MacOS
 source venv/bin/activate
 
 # Install tweepy directly


### PR DESCRIPTION
Die Beschreibung im README für die Aktivierung eines Venvs in Linux war falsch, bzw. ist gleich wie in MacOS.